### PR TITLE
[Mozilla Branding Removal] Change Mozilla repository links to hubs-foundation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,25 +17,25 @@ You can read an intro to Behavior graphs here: [Behavior Graphs Intro](docs/intr
 # Installation and Basic Usage
 This add-on is only compatible with **Blender 3.6** and it's not yet compatible with versions above that.
 
-This add-on requires the [Hubs Blender Exporter Addon](https://github.com/MozillaReality/hubs-blender-exporter). You'll need both installed and the Hubs Blender Exporter add-on needs to be loaded before the Behavior Graphs add-on is.
+This add-on requires the [Hubs Blender Exporter Addon](https://github.com/Hubs-Foundation/hubs-blender-exporter). You'll need both installed and the Hubs Blender Exporter add-on needs to be loaded before the Behavior Graphs add-on is.
 
 Behavior graphs is still in alpha state and not part of the main Hubs client branch. That means it will not work on regular hubs instances or on the official hubs demo server. 
 
 There are three ways you can test Behavior Graphs:
-- Your own local instance using [Hubs Compose](https://github.com/mozilla/hubs-compose/)
+- Your own local instance using [Hubs Compose](https://github.com/Hubs-Foundation/hubs-compose/)
 - Your own Hubs instance
 
 ## Hubs compose
-Alternatively, you can use [hubs-compose](https://github.com/mozilla/hubs-compose/) to run the whole stack locally. 
+Alternatively, you can use [hubs-compose](https://github.com/Hubs-Foundation/hubs-compose/) to run the whole stack locally. 
 
-To add support for Behavior Graphs in your Hubs Compose based instance you'll need to checkout the Hubs client [add-ons branch](https://github.com/mozilla/hubs/tree/addons) and install the [Hubs Behavior Graphs add-on](https://github.com/MozillaReality/hubs-behavior-graphs-addon/).
+To add support for Behavior Graphs in your Hubs Compose based instance you'll need to checkout the Hubs client [add-ons branch](https://github.com/Hubs-Foundation/hubs/tree/addons) and install the [Hubs Behavior Graphs add-on](https://github.com/Hubs-Foundation/hubs-behavior-graphs-addon/).
 
 To use your local Hubs Compose instance you'll need to add the instance home URL to your server list.
 
 ![Testing instance](/docs/img/intro-hubs-compose-instance.png)
 
 ## Your own Hubs instance
-If you are lucky enough to have your own Hubs instance or have access to client customization in your favorite Hubs provider, you add Behavior Graphs support by using the [add-ons branch](https://github.com/mozilla/hubs/tree/addons) and installing the [Hubs Behavior Graphs add-on](https://github.com/MozillaReality/hubs-behavior-graphs-addon/).
+If you are lucky enough to have your own Hubs instance or have access to client customization in your favorite Hubs provider, you add Behavior Graphs support by using the [add-ons branch](https://github.com/Hubs-Foundation/hubs/tree/addons) and installing the [Hubs Behavior Graphs add-on](https://github.com/Hubs-Foundation/hubs-behavior-graphs-addon/).
 
 Then you can add your instance home URL to you server list in the Hubs Blender add-on and to start using it.
 
@@ -52,16 +52,16 @@ You can use any of these query parameters by adding them to your Hubs URL:
 ?newLoader&ecsDebug&vr_entry_type=2d_now&entity_state_api
 ```
 
-**Note**: If you are using the Hubs Blender add-on scene debugger, that will be handled for you automatically by the debugger when a room is created/opened. You can read more about the Hubs Scene Debugger [here](https://github.com/MozillaReality/hubs-blender-exporter/wiki/Hubs-scene-debugger)
+**Note**: If you are using the Hubs Blender add-on scene debugger, that will be handled for you automatically by the debugger when a room is created/opened. You can read more about the Hubs Scene Debugger [here](https://github.com/Hubs-Foundation/hubs-blender-exporter/wiki/Hubs-scene-debugger)
 
 ## Networked Behaviors
-To test networked behaviors in a scene, you'll need to publish the scene and change the room scene in the client so all connected clients are using the same scene. You can quickly and easily publish a scene from Blender using the [Hubs Scene Debugger](https://github.com/MozillaReality/hubs-blender-exporter/wiki/Hubs-scene-debugger).
+To test networked behaviors in a scene, you'll need to publish the scene and change the room scene in the client so all connected clients are using the same scene. You can quickly and easily publish a scene from Blender using the [Hubs Scene Debugger](https://github.com/Hubs-Foundation/hubs-blender-exporter/wiki/Hubs-scene-debugger).
 
 # Demos
-You can find some demo scenes in the [BGs demo repository](https://github.com/MozillaReality/blender-behavior-graph-examples). We will be adding future demos to that repository.
+You can find some demo scenes in the [BGs demo repository](https://github.com/Hubs-Foundation/blender-behavior-graph-examples). We will be adding future demos to that repository.
 
 # Contributing
-If you find any bugs related to the Behavior Graphs Blender add-on, you can file bugs so we can [track the open issues here](https://github.com/MozillaReality/blender-gltf-behavior-graph/issues).
+If you find any bugs related to the Behavior Graphs Blender add-on, you can file bugs so we can [track the open issues here](https://github.com/Hubs-Foundation/blender-gltf-behavior-graph/issues).
 
 # Troubleshooting
 If you see any Behavior Graphs add-on related errors when starting Blender (from the Terminal) it might be that the Behavior Graphs add-on is being initializing before the Hubs Blender exporter add-on is. In that case disable/enable the Behavior Graphs add-on to make sure that is initialized after the Blender Hubs add-on is.


### PR DESCRIPTION
Only some links to correct