### PR TITLE
Fix potentially adding a duplicate component when migrating the grabbable component

### DIFF
--- a/components/grabbable.py
+++ b/components/grabbable.py
@@ -40,7 +40,8 @@ class Grabbable(HubsComponent):
             if "networked-object-properties" in host.hubs_component_list.items:
                 remove_component(host, "networked-object-properties")
 
-            add_component(host, NetworkedTransform.get_name())
+            if NetworkedTransform.get_name() not in host.hubs_component_list.items:
+                add_component(host, NetworkedTransform.get_name())
 
         return migration_occurred
 


### PR DESCRIPTION
Depends on: https://github.com/Hubs-Foundation/blender-gltf-behavior-graph/pull/27

Prevents an extra Networked Transform component from being added to the host during the migration of the grabbable component if a Networked Transform component is somehow already present on the host.

This shouldn't generally be needed, but a duplicate Networked Transform component was added during the migration of an old blend file and adding a guard to prevent duplicates doesn't hurt.