### PR TITLE
Fix node add menu in Blender 5.2+

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -10,7 +10,7 @@ bl_info = {
     "blender": (3, 2, 0),
     "category": "Node",
     "author": "netpro2k, keianhzo",
-    "version": (0, 0, 4),
+    "version": (0, 0, 5),
     "location": "Node Editor > Sidebar > Behavior Graph",
     "description": "Create and export GLTF KHR_behavior graphs using Blender's node group editor"
 }

--- a/behavior_graph.py
+++ b/behavior_graph.py
@@ -10,6 +10,7 @@ from io_hubs_addon.io.utils import gather_property
 from .utils import gather_socket_value, type_to_socket, resolve_input_link, resolve_output_link, gather_variable_value, get_prefs
 from .consts import CUSTOM_CATEGORY_NODES, DEPRECATED_NODES, CATEGORY_COLORS, FILTERED_CATEGORIES
 from .sockets import *
+from .ui import node_add_menu_add_node
 
 auto_casts = {
     ("BGHubsEntitySocket", "NodeSocketString"): "BGNode_hubs_entity_toString",
@@ -111,9 +112,8 @@ class NODE_MT_behavior_graphs_subcategory_Media(bpy.types.Menu):
 
     def draw(self, context):
         layout = self.layout
-        from bl_ui import node_add_menu
-        node_add_menu.add_node_type(layout, "BGNode_media_mediaPlayback")
-        node_add_menu.add_node_type(layout, "BGNode_media_onMediaEvent")
+        node_add_menu_add_node(layout, "BGNode_media_mediaPlayback")
+        node_add_menu_add_node(layout, "BGNode_media_onMediaEvent")
 
 
 class NODE_MT_behavior_graphs_subcategory_Text(bpy.types.Menu):
@@ -122,8 +122,7 @@ class NODE_MT_behavior_graphs_subcategory_Text(bpy.types.Menu):
 
     def draw(self, context):
         layout = self.layout
-        from bl_ui import node_add_menu
-        node_add_menu.add_node_type(layout, "BGNode_text_setTextProperties")
+        node_add_menu_add_node(layout, "BGNode_text_setTextProperties")
 
 
 class NODE_MT_behavior_graphs_subcategory_Custom_Tags(bpy.types.Menu):
@@ -132,10 +131,9 @@ class NODE_MT_behavior_graphs_subcategory_Custom_Tags(bpy.types.Menu):
 
     def draw(self, context):
         layout = self.layout
-        from bl_ui import node_add_menu
-        node_add_menu.add_node_type(layout, "BGNode_hubs_entity_components_custom_tags_addTag")
-        node_add_menu.add_node_type(layout, "BGNode_hubs_entity_components_custom_tags_removeTag")
-        node_add_menu.add_node_type(layout, "BGNode_hubs_entity_components_custom_tags_hasTag")
+        node_add_menu_add_node(layout, "BGNode_hubs_entity_components_custom_tags_addTag")
+        node_add_menu_add_node(layout, "BGNode_hubs_entity_components_custom_tags_removeTag")
+        node_add_menu_add_node(layout, "BGNode_hubs_entity_components_custom_tags_hasTag")
 
 
 class NODE_MT_behavior_graphs_subcategory_String_Math(bpy.types.Menu):
@@ -144,10 +142,9 @@ class NODE_MT_behavior_graphs_subcategory_String_Math(bpy.types.Menu):
 
     def draw(self, context):
         layout = self.layout
-        from bl_ui import node_add_menu
         values = next(values for key, values in behavior_graph_node_categories.items() if key == self.bl_label)
         for value in values:
-            node_add_menu.add_node_type(layout, value.nodetype)
+            node_add_menu_add_node(layout, value.nodetype)
 
 
 class NODE_MT_behavior_graphs_subcategory_Bool_Math(bpy.types.Menu):
@@ -156,10 +153,9 @@ class NODE_MT_behavior_graphs_subcategory_Bool_Math(bpy.types.Menu):
 
     def draw(self, context):
         layout = self.layout
-        from bl_ui import node_add_menu
         values = next(values for key, values in behavior_graph_node_categories.items() if key == self.bl_label)
         for value in values:
-            node_add_menu.add_node_type(layout, value.nodetype)
+            node_add_menu_add_node(layout, value.nodetype)
 
 
 class NODE_MT_behavior_graphs_subcategory_Int_Math(bpy.types.Menu):
@@ -168,10 +164,9 @@ class NODE_MT_behavior_graphs_subcategory_Int_Math(bpy.types.Menu):
 
     def draw(self, context):
         layout = self.layout
-        from bl_ui import node_add_menu
         values = next(values for key, values in behavior_graph_node_categories.items() if key == self.bl_label)
         for value in values:
-            node_add_menu.add_node_type(layout, value.nodetype)
+            node_add_menu_add_node(layout, value.nodetype)
 
 
 class NODE_MT_behavior_graphs_subcategory_Float_Math(bpy.types.Menu):
@@ -180,10 +175,9 @@ class NODE_MT_behavior_graphs_subcategory_Float_Math(bpy.types.Menu):
 
     def draw(self, context):
         layout = self.layout
-        from bl_ui import node_add_menu
         values = next(values for key, values in behavior_graph_node_categories.items() if key == self.bl_label)
         for value in values:
-            node_add_menu.add_node_type(layout, value.nodetype)
+            node_add_menu_add_node(layout, value.nodetype)
 
 
 class NODE_MT_behavior_graphs_subcategory_Vec3_Math(bpy.types.Menu):
@@ -192,10 +186,9 @@ class NODE_MT_behavior_graphs_subcategory_Vec3_Math(bpy.types.Menu):
 
     def draw(self, context):
         layout = self.layout
-        from bl_ui import node_add_menu
         values = next(values for key, values in behavior_graph_node_categories.items() if key == self.bl_label)
         for value in values:
-            node_add_menu.add_node_type(layout, value.nodetype)
+            node_add_menu_add_node(layout, value.nodetype)
 
 
 class NODE_MT_behavior_graphs_subcategory_Euler_Math(bpy.types.Menu):
@@ -204,10 +197,9 @@ class NODE_MT_behavior_graphs_subcategory_Euler_Math(bpy.types.Menu):
 
     def draw(self, context):
         layout = self.layout
-        from bl_ui import node_add_menu
         values = next(values for key, values in behavior_graph_node_categories.items() if key == self.bl_label)
         for value in values:
-            node_add_menu.add_node_type(layout, value.nodetype)
+            node_add_menu_add_node(layout, value.nodetype)
 
 
 class NODE_MT_behavior_graphs_subcategory_Entity_Events(bpy.types.Menu):
@@ -216,11 +208,10 @@ class NODE_MT_behavior_graphs_subcategory_Entity_Events(bpy.types.Menu):
 
     def draw(self, context):
         layout = self.layout
-        from bl_ui import node_add_menu
-        node_add_menu.add_node_type(layout, "BGNode_hubs_onInteract")
-        node_add_menu.add_node_type(layout, "BGNode_hubs_onCollisionEnter")
-        node_add_menu.add_node_type(layout, "BGNode_hubs_onCollisionStay")
-        node_add_menu.add_node_type(layout, "BGNode_hubs_onCollisionExit")
+        node_add_menu_add_node(layout, "BGNode_hubs_onInteract")
+        node_add_menu_add_node(layout, "BGNode_hubs_onCollisionEnter")
+        node_add_menu_add_node(layout, "BGNode_hubs_onCollisionStay")
+        node_add_menu_add_node(layout, "BGNode_hubs_onCollisionExit")
 
 
 class NODE_MT_behavior_graphs_subcategory_Player_Events(bpy.types.Menu):
@@ -229,12 +220,11 @@ class NODE_MT_behavior_graphs_subcategory_Player_Events(bpy.types.Menu):
 
     def draw(self, context):
         layout = self.layout
-        from bl_ui import node_add_menu
-        node_add_menu.add_node_type(layout, "BGNode_hubs_onPlayerCollisionEnter")
-        node_add_menu.add_node_type(layout, "BGNode_hubs_onPlayerCollisionStay")
-        node_add_menu.add_node_type(layout, "BGNode_hubs_onPlayerCollisionExit")
-        node_add_menu.add_node_type(layout, "BGNode_hubs_onPlayerJoined")
-        node_add_menu.add_node_type(layout, "BGNode_hubs_onPlayerLeft")
+        node_add_menu_add_node(layout, "BGNode_hubs_onPlayerCollisionEnter")
+        node_add_menu_add_node(layout, "BGNode_hubs_onPlayerCollisionStay")
+        node_add_menu_add_node(layout, "BGNode_hubs_onPlayerCollisionExit")
+        node_add_menu_add_node(layout, "BGNode_hubs_onPlayerJoined")
+        node_add_menu_add_node(layout, "BGNode_hubs_onPlayerLeft")
 
 
 class NODE_MT_behavior_graphs_subcategory_Lifecycle_Events(bpy.types.Menu):
@@ -243,10 +233,9 @@ class NODE_MT_behavior_graphs_subcategory_Lifecycle_Events(bpy.types.Menu):
 
     def draw(self, context):
         layout = self.layout
-        from bl_ui import node_add_menu
-        node_add_menu.add_node_type(layout, "BGNode_lifecycle_onStart")
-        node_add_menu.add_node_type(layout, "BGNode_lifecycle_onEnd")
-        node_add_menu.add_node_type(layout, "BGNode_lifecycle_onTick")
+        node_add_menu_add_node(layout, "BGNode_lifecycle_onStart")
+        node_add_menu_add_node(layout, "BGNode_lifecycle_onEnd")
+        node_add_menu_add_node(layout, "BGNode_lifecycle_onTick")
 
 
 class NODE_MT_behavior_graphs_subcategory_Media_Frame(bpy.types.Menu):
@@ -255,8 +244,7 @@ class NODE_MT_behavior_graphs_subcategory_Media_Frame(bpy.types.Menu):
 
     def draw(self, context):
         layout = self.layout
-        from bl_ui import node_add_menu
-        node_add_menu.add_node_type(layout, "BGNode_media_frame_setMediaFrameProperty")
+        node_add_menu_add_node(layout, "BGNode_media_frame_setMediaFrameProperty")
 
 
 class NODE_MT_behavior_graphs_subcategory_Rigid_Body(bpy.types.Menu):
@@ -265,8 +253,7 @@ class NODE_MT_behavior_graphs_subcategory_Rigid_Body(bpy.types.Menu):
 
     def draw(self, context):
         layout = self.layout
-        from bl_ui import node_add_menu
-        node_add_menu.add_node_type(layout, "BGNode_physics_setRigidBodyActive")
+        node_add_menu_add_node(layout, "BGNode_physics_setRigidBodyActive")
 
 
 class BGSubcategory(NodeItem):

--- a/ui.py
+++ b/ui.py
@@ -71,6 +71,14 @@ def draw_header(self, context):
         original_NODE_HT_header_draw(self, context)
 
 
+def node_add_menu_add_node(layout, node_type):
+    from bl_ui import node_add_menu
+    if bpy.app.version >= (5, 0, 0):
+        node_add_menu.AddNodeMenu.node_operator(layout, node_type)
+    else:
+        node_add_menu.add_node_type(layout, node_type)
+
+
 class BGNew(bpy.types.Operator):
     bl_idname = "ui.bg_new"
     bl_label = "New Behavior Graph"


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Adds a wrapper function to call the correct Blender function for adding subcategory nodes to the node add menu depending on the Blender version.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
Blender removed the function we were using to add subcategory nodes to the add menu in Blender 5.2, but the new method that replaced it was only first introduced in Blender 5.0, so a wrapper function that calls the correct one for each Blender version is needed.

## Examples
<!-- OPTIONAL — If applicable, give examples of the changes the user will observe, e.g. screenshots, videos, diagrams, console output, etc., otherwise put "N/A" or remove the section.  Including examples of before the PR and after the PR is encouraged. -->
N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Open Blender 5.2
2. Switch the 3D Viewport editor to a Behavior Graph editor.
3. Create a new Behavior Graph.
4. Navigate through all the menus/submenus of the Add menu.
5. See that everything works correctly.
6. Go to Add > Event > Lifecycle Events and select `On Start`.
7. See that the `On Start` node is added.

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
No functionality is changed, so no documentation is needed.

## Limitations
<!-- OPTIONAL — If there is anything you decided not to do/support in this PR that might otherwise be expected, list them here along with the reason why you didn't do/support them, otherwise put "None" -->
None.

## Alternative implementations considered
<!-- OPTIONAL — If there are any alternative ways of implementing this change that you thought of, but decided against, list them here along with why they were discarded, otherwise put "None" -->
Having the wrapper function return the correct Blender function for the version and then calling the returned function rather than calling the correct function within the wrapper, but this would have increased the complexity and there isn't really any benefit.

## Open questions
<!-- OPTIONAL — If you have any questions, put them here, otherwise put "None" -->
None

## Additional details or related context
<!-- OPTIONAL — If there are any other details that you think the reviewers should be aware of that you didn't put elsewhere, e.g. links to related issues, pull requests, references you used, notes on weird things, attribution, etc., put them here, otherwise put "None" -->
This reduces a bit of code duplication because it consolidates the imports of bl_ui into one single import in the wrapper function.

Blender PR removing the old function we were using: https://projects.blender.org/blender/blender/pulls/158805

The bug was reported by @hrithikwins, and investigated/fixed by @Exairnous, at the 2026-09-10 Community Collaboration Session.